### PR TITLE
ANTS-2291: Make match.js compatible with Nashorn

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/bbc/melanite#README",
   "dependencies": {
-    "glob": "^7.1.1",
     "levenshtein-edit-distance": "^1.0.0",
     "ramda": "0.23.0"
   },

--- a/src/match.js
+++ b/src/match.js
@@ -1,22 +1,34 @@
 'use strict'
 const score = require('levenshtein-edit-distance')
-const {all, any, not, compose, apply, curry, pluck} = require('ramda')
+const ramda = require('ramda')
+
+const all = ramda.all
+const any = ramda.any
+const not = ramda.not
+const compose = ramda.compose
+const apply = ramda.apply
+const curry = ramda.curry
+const pluck = ramda.pluck
 
 // includesAll :: String -> [String] -> Boolean
-const includesAll = (haystack, needles) =>
-  all((needle) => haystack.includes(needle), needles)
+const includesAll = function(haystack, needles){
+  return all(function(needle) {return haystack.indexOf(needle)>=0}, needles)
+}
 
 // includesAny :: String -> [String] -> Boolean
-const includesAny = (haystack, needles) =>
-  any((needle) => haystack.includes(needle), needles)
+const includesAny = function(haystack, needles){
+  return any(function(needle) {return haystack.indexOf(needle)>=0}, needles)
+}
 
 // hasInvariants :: ua -> matcher -> bool
-const hasAllInvariants = (ua, deviceMatcher) =>
-  includesAll(ua, deviceMatcher.invariants)
+const hasAllInvariants = function(ua, deviceMatcher) {
+  return includesAll(ua, deviceMatcher.invariants)
+}
 
 // hasDisallowed :: ua -> matcher -> bool
-const hasDisallowed = (ua, deviceMatcher) =>
-  includesAny(ua, deviceMatcher.disallowed)
+const hasDisallowed = function(ua, deviceMatcher) {
+  return includesAny(ua, deviceMatcher.disallowed)
+}
 
 // noDisallowed :: ua -> matcher -> bool
 const hasNoDisallowed = compose(not, hasDisallowed)
@@ -24,18 +36,20 @@ const hasNoDisallowed = compose(not, hasDisallowed)
 const validators = [hasAllInvariants, hasNoDisallowed]
 
 // isValidFor :: ua -> matcher -> [matcher] -> [matcher]
-const isValidFor = curry((ua, deviceMatcher) =>
-  all((f) => f(ua, deviceMatcher), validators))
+const isValidFor = curry(function(ua, deviceMatcher) {
+  return all(function(f) {return f(ua, deviceMatcher)}, validators)
+})
 
 // matchCandidateDevices :: ua -> [matcher] -> [matcher]
-const matchCandidateDevices = (ua, matchers) =>
-  matchers.filter(isValidFor(ua))
+const matchCandidateDevices = function(ua, matchers) {
+ return matchers.filter(isValidFor(ua))
+}
 
 // findBestMatch :: ua -> [matcher] -> device
-const findBestMatch = curry((ua, matches) => {
+const findBestMatch = curry(function(ua, matches) {
   const best = apply(Math.min)
   const fuzzies = pluck('fuzzy', matches)
-  const scores = fuzzies.map((fuzzy) => score(ua, fuzzy))
+  const scores = fuzzies.map(function(fuzzy) {return score(ua, fuzzy)})
   const bestScoreIndex = scores.indexOf(best(scores))
 
   const device = matches[bestScoreIndex] || {brand: 'generic', model: 'device', type: 'unknown'}
@@ -44,7 +58,7 @@ const findBestMatch = curry((ua, matches) => {
 })
 
 // bestMatch :: [matcher] -> ua -> device
-module.exports = curry((matchers, ua) => {
+module.exports = curry(function(matchers, ua) {
   const matches = matchCandidateDevices(ua, matchers)
   return findBestMatch(ua, matches)
 })


### PR DESCRIPTION
Things to consider:
- Nashorn for Java 8 doesn't support => anonymous functions
- Nashorn doesn't support natively CommonJS modules. We are using https://github.com/coveo/nashorn-commonjs-modules to emulate them. 
- Nashorn doesn't support object deconstruction ie `const {a, b, c} = require('module')`    
- Glob dependency is not used - I removed it